### PR TITLE
swtiched sorting to use layer index instead of drawIndex

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opengis",
   "homepage": "https://opengis.simcoe.ca/public/",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "private": true,
   "dependencies": {
     "array-move": "^2.2.2",

--- a/src/sidebar/components/toc/TOC.jsx
+++ b/src/sidebar/components/toc/TOC.jsx
@@ -594,7 +594,10 @@ updateLayerCount = (numLayers) => {
     }
     let group = Object.assign({},this.state.selectedGroup);
     TOCHelpers.updateLayerIndex(arrayMove(group.layers, oldIndex, newIndex), (result) => {
-      group.layers = result;
+      group.layers = result.map(layer=> {
+                                          layer.index = layer.drawIndex;
+                                          return layer;
+                                        });
     
       this.setLayerGroups(this.state.type, this.state.layerListGroups.map((item)=> group.value === item.value? group:item),()=>
       {

--- a/src/sidebar/components/toc/common/TOCHelpers.jsx
+++ b/src/sidebar/components/toc/common/TOCHelpers.jsx
@@ -1145,10 +1145,10 @@ export function sortByAlphaCompare(a, b) {
   return 0;
 }
 export function sortByIndexCompare(a, b) {
-  if (a.drawIndex > b.drawIndex) {
+  if (a.index > b.index) {
     return -1;
   }
-  if (a.drawIndex < b.drawIndex) {
+  if (a.index < b.index) {
     return 1;
   }
   return 0;


### PR DESCRIPTION
update layer index on sort move to ensure user sorting is maintained after a-z sorting toggle