### PR TITLE
Vector tile support - mainSidebarItems Options

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "npm": "^6.14.11",
     "ol": "^6.5.0",
     "ol-contextmenu": "^3.3.2",
+    "ol-mapbox-style": "^6.5.1",
     "proj4": "^2.7.0",
     "rc-menu": "^7.5.5",
     "rc-slider": "^8.7.1",

--- a/src/header/Search.jsx
+++ b/src/header/Search.jsx
@@ -521,7 +521,7 @@ class Search extends Component {
 		}
 
 		// TOOLS
-		if (selectedType === "All" || selectedType === "Tool") {
+		if ((selectedType === "All" || selectedType === "Tool") && (window.config.mainSidebarItems !== undefined && window.config.mainSidebarItems["hideTools"] !== true)) {
 			let tools = [];
 			// eslint-disable-next-line
 			window.config.sidebarToolComponents.forEach((tool) => {
@@ -537,7 +537,7 @@ class Search extends Component {
 		}
 
 		// THEMES
-		if (selectedType === "All" || selectedType === "Theme") {
+		if ((selectedType === "All" || selectedType === "Theme") && (window.config.mainSidebarItems !== undefined && window.config.mainSidebarItems["hideThemes"] !== true)) {
 			let themes = [];
 			window.config.sidebarThemeComponents.forEach((theme) => {
 				if (theme.name.toUpperCase().indexOf(this.state.value.toUpperCase()) >= 0 && (theme.enabled === undefined || theme.enabled)) {

--- a/src/helpers/helpers.js
+++ b/src/helpers/helpers.js
@@ -5,8 +5,11 @@ import ReactDOM from "react-dom";
 // OPEN LAYERS
 import Feature from "ol/Feature";
 import * as ol from "ol";
-import { Image as ImageLayer, Tile as TileLayer, Vector as VectorLayer } from "ol/layer.js";
-import { ImageWMS, OSM, TileArcGISRest, TileImage, Vector, XYZ } from "ol/source.js";
+import { Image as ImageLayer, Tile as TileLayer, Vector as VectorLayer, VectorTile as VectorTileLayer } from "ol/layer.js";
+import { ImageWMS, OSM, TileArcGISRest, TileImage, Vector, XYZ} from "ol/source.js";
+import MVT from 'ol/format/MVT';
+import VectorTileSource from 'ol/source/VectorTile';
+import stylefunction from 'ol-mapbox-style/dist/stylefunction';
 
 //import {file as FileLoader} from "ol/featureloader.js";
 import { GeoJSON, WKT } from "ol/format.js";
@@ -351,6 +354,45 @@ export function getImageWMSLayer(serverURL, layers, serverType = "geoserver", cq
   });
   return imageLayer;
 }
+
+//GET VectorTie Layer
+export function getVectorTileLayer(url) {
+  let layer = new VectorTileLayer({
+    renderMode: 'vector',
+    reload: Infinity,
+    declutter: true,
+    //extent: extent,
+    source: new VectorTileSource({
+      attributions: "LIO VectorTiles Test",
+      format: new MVT(),
+      url: url + "/tile/{z}/{y}/{x}.pbf",
+      maxZoom: 26,
+      //rootPath: url + "/resources/styles/root.json",
+      //spritePath: url + "/resources/sprites/sprite.json",
+      //pngPath: url + "/resources/sprites/sprite.png",   
+    }),
+    id: "vTileLayer",
+    tilePixelRatio: 8,
+  });
+  //let rootPath= url + "/tile/{z}/{y}/{x}.pbf"; // rootPath for applySytle
+  let rootPath = url + "/resources/styles/root.json";
+  let spritePath = url + "/resources/sprites/sprite.json";
+  let pngPath = url + "/resources/sprites/sprite.png";
+  fetch(rootPath).then(function (response) {
+    response.json().then(function (glStyle) {
+      fetch(spritePath).then(function (response) {
+        response.json().then(function (spriteData) {
+  
+          stylefunction(layer, glStyle, "esri", undefined, spriteData, pngPath);
+          
+           });
+        });
+    });
+  });
+  
+  return layer //StyledLayer is returned;
+};
+
 
 export function scaleToResolution(scale) {
   const DOTS_PER_INCH = 96;

--- a/src/map/BasicBasemapSwitcher.jsx
+++ b/src/map/BasicBasemapSwitcher.jsx
@@ -69,6 +69,8 @@ class BasicBasemapSwitcher extends Component {
           layer = helpers.getESRITileXYZLayer(service.url);
         }else if (service.type === "XYZ") {
           layer = helpers.getXYZLayer(service.url);
+        }else if (service.type === "ESRI_VECTOR_TILED") {
+          layer = helpers.getVectorTileLayer(service.url);
         }else{
           layer = new VectorLayer({source: new VectorSource()});
         }

--- a/src/sidebar/MenuButton.jsx
+++ b/src/sidebar/MenuButton.jsx
@@ -55,15 +55,19 @@ class MenuButton extends Component {
 			if (theme.enabled === undefined || theme.enabled)
 				itemList.push(<MenuItem onClick={() => this.itemClick(theme.name, "themes")} key={helpers.getUID()} name={theme.name} iconClass={"sc-menu-theme-icon"} />);
 		});
-
-		return itemList;
+		if (itemList === 0 || (window.config.mainSidebarItems !== undefined && window.config.mainSidebarItems["hideThemes"])) {
+		return;
+	   }else{
+		 return itemList;}
 	};
 
 	// CUSTOM ENTRIES, COMMENT OUT IF YOU DON"T WANT IT
 	getOthers = () => {
 		let itemList = [];
 		itemList.push(<MenuItem onClick={() => helpers.showURLWindow(window.config.whatsNewUrl, true, "full", false, true)} key={helpers.getUID()} name={"What's New"} iconClass={"sc-menu-terms-icon"} />);
+		{ if (!window.config.ShowHelpButtonInsteadOfFeedback)
 		itemList.push(<MenuItem key={helpers.getUID()} name={"Feedback"} iconClass={"sc-menu-feedback-icon"} onClick={this.onFeedbackClick} />);
+		}
 		itemList.push(<MenuItem onClick={this.onScreenshotClick} key={helpers.getUID()} name={"Take a Screenshot"} iconClass={"sc-menu-screenshot-icon"} />);
 		itemList.push(<MenuItem key={helpers.getUID()} name={"Map Legend"} iconClass={"sc-menu-legend-icon"} onClick={() => window.emitter.emit("openLegend", null)} />);
 		itemList.push(<MenuItem onClick={() => helpers.showURLWindow(window.config.helpUrl, false, "full", false, true)} key={helpers.getUID()} name={"Help"} iconClass={"sc-menu-help-icon"} />);
@@ -144,9 +148,11 @@ class MenuButton extends Component {
 					</button>
 				</div>
 				<div id="sc-menu-button-list-container" className={menuListClassName}>
-					<div className="sc-menu-list-item-heading" style={{ paddingTop: "0px" }}>
-						MAP THEMES
-					</div>
+					{(window.config.mainSidebarItems !== undefined && window.config.mainSidebarItems["hideThemes"])? <div></div>:
+						<div className="sc-menu-list-item-heading" style={{ paddingTop: "0px" }}>
+							MAP THEMES
+						</div>
+					}	
 					{this.themes}
 					<div className="sc-menu-list-item-heading">MAP TOOLS</div>
 					{this.tools}

--- a/src/sidebar/Sidebar.jsx
+++ b/src/sidebar/Sidebar.jsx
@@ -134,17 +134,22 @@ class Sidebar extends Component {
       });
     });
     helpers.waitForLoad("settings", Date.now(), 30, () => {
-      // IMPORT TOOLS FROM CONFIG
-
+      // IMPORT TOOLS FROM CONFIG and CHECK VISIBILITY
       let tools = window.config.sidebarToolComponents;
       tools = tools.filter((item) => item.enabled === undefined || item.enabled);
       tools.map(async (component) => await this.addComponent(component, "tools"));
-      if (tools.length === 0) this.setState({ hideTools: true });
+      if (tools.length === 0 || (window.config.mainSidebarItems !== undefined && window.config.mainSidebarItems["hideTools"])) this.setState({ hideTools: true });
       // IMPORT THEMES FROM CONFIG
       let themes = window.config.sidebarThemeComponents;
       themes = themes.filter((item) => item.enabled === undefined || item.enabled);
       themes.map(async (component) => await this.addComponent(component, "themes"));
-      if (themes.length === 0) this.setState({ hideThemes: true });
+      if (themes.length === 0 || (window.config.mainSidebarItems !== undefined && window.config.mainSidebarItems["hideThemes"])) this.setState({ hideThemes: true });
+      // CHECK VISIBILITY OF LAYERS MENUE
+      if (themes.length === 0 || (window.config.mainSidebarItems !== undefined && window.config.mainSidebarItems["hideLayers"])) this.setState({ hideLayers: true });
+      // CHECK VISIBILITY OF MY MAPS
+      if (themes.length === 0 || (window.config.mainSidebarItems !== undefined && window.config.mainSidebarItems["hideMyMaps"])) this.setState({ hideMyMaps: true });
+      // CHECK VISIBILITY OF REPORTS
+      if (themes.length === 0 || (window.config.mainSidebarItems !== undefined && window.config.mainSidebarItems["hideReports"])) this.setState({ hideReports: true });
 
       const shortcuts = window.config.sidebarShortcutParams;
       // HANDLE ADVANCED MODE PARAMETER


### PR DESCRIPTION
Added VectorTile support and Configuration Options to control visibility of mainSidebarItems. Default behavior is if mainSidebarItems is not presented in the configurations.

  "mainSidebarItems": {
    "hideTools": false,
    "hideThemes": true,
    "hideLayers": false,
    "hideMyMaps": false,
    "hideReports": false
  },

