### PR TITLE
Highlight/select feature style options & resolving IDENTIFY_TITLE_COLUMN keywords are not respected issue.

### DIFF
--- a/docs/Map/URLParameters.md
+++ b/docs/Map/URLParameters.md
@@ -20,8 +20,8 @@ https://opengis.simcoe.ca/?TAB=MyMaps
 
 #### COORDINATES
 
-https://opengis.simcoe.ca/?X=-8877179.097241182&Y=5534758.639315502  
-https://opengis.simcoe.ca/?X=-79.74503517150879&Y=44.44612812682391&SR=WGS84
+https://opengis.simcoe.ca/?X=-8877179.097241182&Y=5534758.639315502[&ID=TRUE]
+https://opengis.simcoe.ca/?X=-79.74503517150879&Y=44.44612812682391&SR=WGS84[&ID=TRUE]
 
 #### EXTENT
 

--- a/src/config.json
+++ b/src/config.json
@@ -36,7 +36,8 @@
   "gitHubFollowHandle": "Follow @simcoecountygis",
   "pushMapNotifications": false,
   "pushMapNotificationIDs": [1,5,6],
-  "ShowHelpButtonInsteadOfFeedback" : false,
+  "showHelpButtonInsteadOfFeedback" : false,
+  "onCoordinateZoomID": false,
 
   "centerCoords": [-8878504.68, 5543492.45],
   "defaultZoom": 10,

--- a/src/header/Header.jsx
+++ b/src/header/Header.jsx
@@ -104,7 +104,7 @@ class Header extends Component {
 				<div id="sc-header-search-container">
 					<Search options={this.props.options} />
 				</div>
-				{ (window.config.ShowHelpButtonInsteadOfFeedback)?
+				{ (window.config.showHelpButtonInsteadOfFeedback)?
 					<div className="sc-header-help-container" >
 						<div className="sc-header-help-btn" onClick={() => helpers.showURLWindow(window.config.helpUrl, false, "full")}>?</div>
 					</div>

--- a/src/header/Search.jsx
+++ b/src/header/Search.jsx
@@ -331,25 +331,25 @@ class Search extends Component {
 			searchIconLayer.setZIndex(300);
 		}
 
-		const zoomFactor = (window.config.featureHighlitStyles && window.config.featureHighlitStyles["zoomFactor"] > 1) ? window.config.featureHighlitStyles["zoomFactor"] : 1;
+		const zoomFactor = (window.config.featureHighlitStyles && window.config.featureHighlitStyles["zoomFactor"] >= 0) ? window.config.featureHighlitStyles["zoomFactor"] : 1;
 		if (result.geojson.indexOf("Point") !== - 1) {
 			searchGeoLayer.setStyle(this.styles["point"]);
 			window.map.getView().fit(fullFeature.getGeometry().getExtent(), window.map.getSize(), {
 				duration: 1000,
 			});
-			window.map.getView().setZoom(18);
+			window.map.getView().setZoom(19 - zoomFactor);
 		} else if (result.geojson.indexOf("Line") !== - 1) {
 			searchGeoLayer.setStyle(this.styles["poly"]);
 			window.map.getView().fit(fullFeature.getGeometry().getExtent(), window.map.getSize(), {
 				duration: 1000,
 			});
-			window.map.getView().setZoom(window.map.getView().getZoom() - zoomFactor / window.map.getView().getZoom());
+			window.map.getView().setZoom(window.map.getView().getZoom() - zoomFactor );
 		} else {
 			searchGeoLayer.setStyle(this.styles["poly"]);
 			window.map.getView().fit(fullFeature.getGeometry().getExtent(), window.map.getSize(), {
 				duration: 1000,
 			});
-			window.map.getView().setZoom(window.map.getView().getZoom() - zoomFactor / window.map.getView().getZoom());
+			window.map.getView().setZoom(window.map.getView().getZoom() - zoomFactor );
 		}
 
 		//fullFeature.setStyle(myMapsHelpers.getDefaultDrawStyle([255, 0, 0, 0.8], false, 2, fullFeature.getGeometry().getType()));

--- a/src/header/Search.jsx
+++ b/src/header/Search.jsx
@@ -330,25 +330,26 @@ class Search extends Component {
 			searchGeoLayer.setZIndex(300);
 			searchIconLayer.setZIndex(300);
 		}
-		// SET STYLE AND ZOOM
-		if (result.geojson.indexOf("Point") !== -1) {
+
+		const zoomFactor = (window.config.featureHighlitStyles && window.config.featureHighlitStyles["zoomFactor"] > 1) ? window.config.featureHighlitStyles["zoomFactor"] : 1;
+		if (result.geojson.indexOf("Point") !== - 1) {
 			searchGeoLayer.setStyle(this.styles["point"]);
 			window.map.getView().fit(fullFeature.getGeometry().getExtent(), window.map.getSize(), {
 				duration: 1000,
 			});
 			window.map.getView().setZoom(18);
-		} else if (result.geojson.indexOf("Line") !== -1) {
+		} else if (result.geojson.indexOf("Line") !== - 1) {
 			searchGeoLayer.setStyle(this.styles["poly"]);
 			window.map.getView().fit(fullFeature.getGeometry().getExtent(), window.map.getSize(), {
 				duration: 1000,
 			});
-			window.map.getView().setZoom(window.map.getView().getZoom() - 1 / window.map.getView().getZoom());
+			window.map.getView().setZoom(window.map.getView().getZoom() - zoomFactor / window.map.getView().getZoom());
 		} else {
 			searchGeoLayer.setStyle(this.styles["poly"]);
 			window.map.getView().fit(fullFeature.getGeometry().getExtent(), window.map.getSize(), {
 				duration: 1000,
 			});
-			window.map.getView().setZoom(window.map.getView().getZoom() - 1 / window.map.getView().getZoom());
+			window.map.getView().setZoom(window.map.getView().getZoom() - zoomFactor / window.map.getView().getZoom());
 		}
 
 		//fullFeature.setStyle(myMapsHelpers.getDefaultDrawStyle([255, 0, 0, 0.8], false, 2, fullFeature.getGeometry().getType()));
@@ -356,21 +357,21 @@ class Search extends Component {
 		if (result.geojson.indexOf("Point") !== -1) {
 			const pointStyle = new Style({
 				image: new CircleStyle({
-					radius: 5,
+					radius: (window.config.featureHighlitStyles && window.config.featureHighlitStyles["circleRadius"] !== null && window.config.featureHighlitStyles["circleRadius"] !== undefined) ? window.config.featureHighlitStyles["circleRadius"] : 5,
 					stroke: new Stroke({
-						color: [0, 0, 0, 1],
-						width: 2,
+						color: (window.config.featureHighlitStyles && window.config.featureHighlitStyles["circleStroke"] !== null && window.config.featureHighlitStyles["circleStroke"] !== undefined) ? window.config.featureHighlitStyles["circleStroke"] : [0, 0, 0, 1],
+						width: (window.config.featureHighlitStyles && window.config.featureHighlitStyles["circleStrokeWidth"] !== null && window.config.featureHighlitStyles["circleStrokeWidth"] !== undefined) ? window.config.featureHighlitStyles["circleStrokeWidth"] : 2,
 					}),
 					fill: new Fill({
-						color: [250, 40, 255, 1],
+						color: (window.config.featureHighlitStyles && window.config.featureHighlitStyles["circleFill"] !== null && window.config.featureHighlitStyles["circleFill"] !== undefined) ? window.config.featureHighlitStyles["circleFill"] : [250, 40, 255, 1],
 					}),
 				}),
 			});
 
 			fullFeature.setStyle(pointStyle);
 		} else {
-			let defaultStyle = drawingHelpers.getDefaultDrawStyle([255, 0, 0, 0.8], false, 2, fullFeature.getGeometry().getType());
-			defaultStyle.setFill(new Fill({ color: [255, 0, 0, 0] }));
+			let defaultStyle = drawingHelpers.getDefaultDrawStyle((window.config.featureHighlitStyles && window.config.featureHighlitStyles["stroke"] !== null && window.config.featureHighlitStyles["stroke"] !== undefined) ? window.config.featureHighlitStyles["stroke"] : [255, 0, 0, 0.8], false, (window.config.featureHighlitStyles["strokeWidth"] !== null && window.config.featureHighlitStyles["strokeWidth"] !== undefined) ? window.config.featureHighlitStyles["strokeWidth"] : 2, fullFeature.getGeometry().getType());
+			defaultStyle.setFill(new Fill({ color: (window.config.featureHighlitStyles && window.config.featureHighlitStyles["fill"] !== null && window.config.featureHighlitStyles["fill"] !== undefined) ? window.config.featureHighlitStyles["fill"] : [255, 0, 0, 0] }));
 			fullFeature.setStyle(defaultStyle);
 		}
 	}
@@ -507,8 +508,7 @@ class Search extends Component {
 									type: "Map Layer",
 									layerGroupName: layer.groupName,
 									layerGroup: layer.group,
-									imageName: "layers.png",
-									imageName: (searchResultTOC_Actions == 'advanced' && layer.visible)? "layers-visible.png" : "layers.png" ,
+									imageName: (searchResultTOC_Actions === 'advanced' && layer.visible)? "layers-visible.png" : "layers.png" ,
 									index: layer.index,
 
 								});

--- a/src/helpers/helpers.js
+++ b/src/helpers/helpers.js
@@ -1159,12 +1159,13 @@ export function getGeometryFromGeoJSON(geometry) {
 }
 
 //Generate Feature Reports for a Polygon (reproting area)
-export function generateReport(feature, report, buffer = 0, callback = undefined) {
-  const url = mainConfig.reportsUrl + report;
+export function generateReport(feature, reportObj, buffer = 0, callback = undefined) {
+  const report = reportObj.report;
+  const url = mainConfig.reportsUrl + 'Report/' +  report;
   let geom = feature.getGeometry();
   //const utmNad83Geometry = geom.transform("EPSG:3857", _nad83Proj);
   const geoJSON = getGeoJSONFromGeometry(geom);
-  const obj = { geoJSON: geoJSON, srid: "3857", buffer: buffer };
+  const obj = { geoJSON: geoJSON, srid: "3857", buffer: buffer, reportObj:reportObj};
   return fetch(url, {
     method: "POST", // *GET, POST, PUT, DELETE, etc.
     mode: "cors", // no-cors, cors, *same-origin
@@ -1195,12 +1196,13 @@ export function generateReport(feature, report, buffer = 0, callback = undefined
     });
 }
 
-export function previewReport(feature, report, buffer = 0, callback) {
-  const url = mainConfig.reportsUrl + report;
+export function previewReport(feature, reportObj, buffer = 0, callback) {
+  const report = reportObj.report;
+  const url = mainConfig.reportsUrl + 'ReportPreview/' + report;
   let geom = feature.getGeometry();
   //const utmNad83Geometry = geom.transform("EPSG:3857", _nad83Proj);
   const geoJSON = getGeoJSONFromGeometry(geom);
-  const obj = { geoJSON: geoJSON, srid: "3857", buffer: buffer };
+  const obj = { geoJSON: geoJSON, srid: "3857", buffer: buffer, reportObj:reportObj};
   return fetch(url, {
     method: "POST", // *GET, POST, PUT, DELETE, etc.
     mode: "cors", // no-cors, cors, *same-origin

--- a/src/map/Identify.jsx
+++ b/src/map/Identify.jsx
@@ -377,10 +377,10 @@ const Layer = (props) => {
 
   //console.log(layer);
   let layerObj = {};
-  layerObj = _getLayerObj(layer.name);
-  // _getLayerObj(layer.name, (returnData)=>{
-  //   layerObj=returnData;
-  // });
+  //layerObj = _getLayerObj(layer.name);
+  _getLayerObj(layer.name, (returnData)=>{
+    layerObj=returnData;
+  });
   return (
     <div id="sc-identify-layer-container">
       <Collapsible trigger={layer.type} open={open}>

--- a/src/map/SCMap.jsx
+++ b/src/map/SCMap.jsx
@@ -376,6 +376,7 @@ class SCMap extends Component {
 			const x = helpers.getURLParameter("X");
 			const y = helpers.getURLParameter("Y");
 			const sr = helpers.getURLParameter("SR") === null ? "WEB" : helpers.getURLParameter("SR");
+			const id = helpers.getURLParameter("ID");
 
 			// GET URL PARAMETERS (ZOOM TO EXTENT)
 			const xmin = helpers.getURLParameter("XMIN");
@@ -387,6 +388,25 @@ class SCMap extends Component {
 				// URL PARAMETERS (ZOOM TO XY)
 				let coords = [x, y];
 				if (sr && sr.toUpperCase() === "WGS84") coords = fromLonLat([Math.round(x * 100000) / 100000, Math.round(y * 100000) / 100000]);
+                
+				if (id === "true" || (window.config.onCoordinateZoomID !== undefined && window.config.onCoordinateZoomID !== null && window.config.onCoordinateZoomID)) {
+                	const iconFeature = new Feature({
+					geometry: new Point(coords),
+				  });
+				  
+				  const iconStyle = new Style({
+					image: new Icon({
+						anchor: [0.5, 1],
+						src: images["identify-marker.png"],
+					}),
+				  });
+
+				  iconFeature.setStyle(iconStyle);
+				  this.identifyIconLayer.getSource().clear();
+				  window.map.removeLayer(this.identifyIconLayer);
+				  this.identifyIconLayer.getSource().addFeature(iconFeature);
+				  window.map.addLayer(this.identifyIconLayer);
+				}; 
 
 				setTimeout(() => {
 					helpers.flashPoint(coords);

--- a/src/sidebar/MenuButton.jsx
+++ b/src/sidebar/MenuButton.jsx
@@ -65,7 +65,7 @@ class MenuButton extends Component {
 	getOthers = () => {
 		let itemList = [];
 		itemList.push(<MenuItem onClick={() => helpers.showURLWindow(window.config.whatsNewUrl, true, "full", false, true)} key={helpers.getUID()} name={"What's New"} iconClass={"sc-menu-terms-icon"} />);
-		{ if (!window.config.ShowHelpButtonInsteadOfFeedback)
+		{ if (!window.config.showHelpButtonInsteadOfFeedback)
 		itemList.push(<MenuItem key={helpers.getUID()} name={"Feedback"} iconClass={"sc-menu-feedback-icon"} onClick={this.onFeedbackClick} />);
 		}
 		itemList.push(<MenuItem onClick={this.onScreenshotClick} key={helpers.getUID()} name={"Take a Screenshot"} iconClass={"sc-menu-screenshot-icon"} />);

--- a/src/sidebar/components/mymaps/FeatureReportPopup.jsx
+++ b/src/sidebar/components/mymaps/FeatureReportPopup.jsx
@@ -28,11 +28,12 @@ class FeatureReportPopup extends Component {
 
   loadReportOptions(callback=undefined) {
     this.setState({isLoading:true});
-    helpers.getJSON(mainConfig.reportsUrl,(results)=>{
-      let reportOptions = [];
+  //helpers.getJSON(mainConfig.reportsUrl,(results)=>{
+  const results = window.config.reports;
+     let reportOptions = [];
       reportOptions = results.map((item)=> {return {label:item.title, value:item.title}});
       this.setState({reports:results,reportOptions:reportOptions,reportOption:reportOptions[0], isLoading:false});
-    });
+ // });
  
   }
   getSelectedReport = (reportTitle) => {
@@ -40,7 +41,7 @@ class FeatureReportPopup extends Component {
   }
   onPreviewReport(report, buffer){
     let selectedReport = this.getSelectedReport(report);
-    helpers.previewReport(drawingHelpers.getFeatureById(this.props.item.id), selectedReport.preview, buffer, (summaryData) =>{
+    helpers.previewReport(drawingHelpers.getFeatureById(this.props.item.id), selectedReport, buffer, (summaryData) =>{
       if (summaryData === undefined || summaryData === null || summaryData.length === 0) {
         helpers.showMessage("Not Found", "There were no results for the current selection");
       }else{
@@ -53,7 +54,7 @@ class FeatureReportPopup extends Component {
   onGenerateReport(report, buffer) {
     let selectedReport = this.getSelectedReport(report);
    
-    helpers.generateReport(drawingHelpers.getFeatureById(this.props.item.id), selectedReport.report, buffer, ()=>{
+    helpers.generateReport(drawingHelpers.getFeatureById(this.props.item.id), selectedReport, buffer, ()=>{
       this.setState({isLoading:false});
     });
   


### PR DESCRIPTION
Adding FeatureHighliteStyle and ZoomFactor parameters to DB Config. When the featureHighlitStyles is not present in the configuration default will be existing Simcoe Map parameters. Following is a sample "featureHighlitStyles" configuration used for i-Map.

  "featureHighlitStyles": {
    "zoomFactor":2,
    "stroke":[102, 255, 102, 0.3],
     "fill": [102, 255, 102, 0.3],
     "strokeWidth": 6,
     "circleStroke":[0, 0, 0, 1],
     "circleFill": [250, 40, 255, 1],
     "circleStrokeWidth": 2,
      "circleRadius": 5
  },
